### PR TITLE
Add features to bulk import for assessing and tracking results

### DIFF
--- a/arcflow/utils/bulk_import.py
+++ b/arcflow/utils/bulk_import.py
@@ -68,6 +68,7 @@ def get_resource_id_from_ead(ead_id, asnake_client):
         return None
 
 def report_csv_error(report_dict, error_string):
+    """Function to print and log error messages (assumes only one error message)."""
     report_dict["error"] = error_string
     print(error_string)
 
@@ -154,6 +155,7 @@ def csv_bulk_import(csv_directory=None, load_type='ao', only_validate='false'):
     return bulk_import_report
 
 def save_report(path, report_list, validate_only):
+    """Function to create and save reports for tracking bulk imports."""
     current_datetime = datetime.now().strftime('%Y-%m-%d-%H%M%S')
     action = "validate" if validate_only else "import"
     suffix = current_datetime + "_" + action
@@ -181,6 +183,7 @@ def save_report(path, report_list, validate_only):
             writer.writerow(row)
 
 def check_job_status(client, repo_id, job_id):
+    """Function to check whether a job has completed (and thus output files are ready)."""
     while True:
         job_status_response = client.get(f'/repositories/{repo_id}/jobs/{job_id}')
         job_status = job_status_response.json()['status']
@@ -197,6 +200,7 @@ def check_job_status(client, repo_id, job_id):
             time.sleep(pause)
 
 def retrieve_job_output(path, report_list):
+    """Function to retrieve and save last created output files for each job in the bulk import."""
     client = __get_asnake_client()
     for row in report_list:
         repo_id = row["repo_id"]

--- a/arcflow/utils/bulk_import.py
+++ b/arcflow/utils/bulk_import.py
@@ -71,7 +71,6 @@ def check_for_children(repo_id, rid, asnake_client):
     """Function to check how many top-level children a resource already has. Returns integer value for the number of children or -1 if encounters an error."""
     try:
         info = asnake_client.get(f"/repositories/{repo_id}/resources/{rid}/tree/root").json()
-        print(json.dumps(info, indent=4))
         if 'child_count' not in info:
             return -1
 
@@ -132,15 +131,16 @@ def csv_bulk_import(csv_directory=None, load_type='ao', only_validate='false'):
         file_import_report["repo_id"] = repo
         file_import_report["rid"] = rid
 
-        child_count = check_for_children(repo, rid, client)
-        if child_count > 0:
-            report_csv_error(file_import_report, f'EAD ID {ead_id} already has {child_count} top-level children in ASpace. Not imported.')
-            bulk_import_report.append(file_import_report)
-            continue
-        elif child_count == -1:
-            report_csv_error(file_import_report, f'Error checking children for EAD ID {ead_id}. Not imported.')
-            bulk_import_report.append(file_import_report)
-            continue
+        if load_type == "ao":
+            child_count = check_for_children(repo, rid, client)
+            if child_count > 0:
+                report_csv_error(file_import_report, f'EAD ID {ead_id} already has {child_count} top-level children in ASpace. Not imported.')
+                bulk_import_report.append(file_import_report)
+                continue
+            elif child_count == -1:
+                report_csv_error(file_import_report, f'Error checking children for EAD ID {ead_id}. Not imported.')
+                bulk_import_report.append(file_import_report)
+                continue
 
         file_list = []
         with open(f, 'rb') as file:


### PR DESCRIPTION
I've added a few features to bulk_import.py to help with assessing and tracking the results of the bulk import jobs:
* generate a csv and txt report for each bulk import to log and track data for each file in the batch
* provide an option to download the csv output of the import jobs from ASpace (provides more detail on lines in the csv with possible import issues)
* if downloaded, parse the output files and provide a count of the issues in the report document so we can easily identify which ones require additional review
* check whether the resource already has children before importing a csv finding aid (to prevent accidentally adding to an existing finding aid)