### PR TITLE
Import features - add information to report

### DIFF
--- a/arcflow/utils/bulk_import.py
+++ b/arcflow/utils/bulk_import.py
@@ -92,6 +92,7 @@ def csv_bulk_import(csv_directory=None, load_type='ao', only_validate='false', s
         exit(0)
 
     client = __get_asnake_client()
+    aspace_instance_url = client.config['baseurl'].split(":")[1].lstrip("/")
 
     bulk_import_report = []
 
@@ -100,6 +101,7 @@ def csv_bulk_import(csv_directory=None, load_type='ao', only_validate='false', s
         file_import_report = {}
         file_import_report["identifier"] = Path(f).stem
         file_import_report["type"] = load_type
+        file_import_report['aspace_url'] = aspace_instance_url
         file_import_report["only_validate"] = only_validate
 
         ead_id = get_ead_from_csv(f)
@@ -204,7 +206,7 @@ def save_report(path, report_list, validate_only):
 
     report_csv_file_name = report_file_name_stem + ".csv"
 
-    fieldnames = ['identifier','ead_id','repo_id', 'rid','only_validate','type','resource_id','error','results_status','results_warnings','results_id','results_uri',"csv_issue_count"]
+    fieldnames = ['identifier','ead_id','aspace_url','repo_id', 'rid','only_validate','type','resource_id','error','results_status','results_warnings','results_id','results_uri',"csv_issue_count"]
     
     csv_report_save_path = os.path.join(report_save_path, report_csv_file_name)
     with open(csv_report_save_path, "w", newline="", encoding='utf-8') as csvfile:

--- a/arcflow/utils/bulk_import.py
+++ b/arcflow/utils/bulk_import.py
@@ -103,6 +103,7 @@ def csv_bulk_import(csv_directory=None, load_type='ao', only_validate='false', s
         file_import_report["type"] = load_type
         file_import_report['aspace_url'] = aspace_instance_url
         file_import_report["only_validate"] = only_validate
+        file_import_report["import_date"] = datetime.now().strftime('%Y-%m-%d')
 
         ead_id = get_ead_from_csv(f)
         file_import_report["ead_id"] = ead_id
@@ -206,7 +207,7 @@ def save_report(path, report_list, validate_only):
 
     report_csv_file_name = report_file_name_stem + ".csv"
 
-    fieldnames = ['identifier','ead_id','aspace_url','repo_id', 'rid','only_validate','type','resource_id','error','results_status','results_warnings','results_id','results_uri',"csv_issue_count"]
+    fieldnames = ['identifier','ead_id','aspace_url','import_date','repo_id', 'rid', 'only_validate','type','resource_id','error','results_status','results_warnings','results_id','results_uri',"csv_issue_count"]
     
     csv_report_save_path = os.path.join(report_save_path, report_csv_file_name)
     with open(csv_report_save_path, "w", newline="", encoding='utf-8') as csvfile:


### PR DESCRIPTION
Adding two more fields to the report csv and txt files -- the url of the archivesspace instance that the csv was imported or validated with and the date of the import/validation. 

These additional data points will help with tracking what has and has not been uploaded to dev vs. stage and when. 

The URL included in the report is the middle portion of the base url (that is, taking off the protocol and port number) for simplicity/ease of reading.