### PR TITLE
Arclight 17

### DIFF
--- a/arcflow/main.py
+++ b/arcflow/main.py
@@ -34,11 +34,12 @@ class ArcFlow:
     """
 
 
-    def __init__(self, arclight_dir, aspace_dir, solr_url, force_update=False):
+    def __init__(self, arclight_dir, aspace_dir, solr_url, force_update=False, traject_task=''):
         self.solr_url = solr_url
         self.arclight_dir = arclight_dir
         self.aspace_dir = aspace_dir
         self.force_update = force_update
+        self.traject_task = traject_task
 
         self.log = logging.getLogger('arcflow')
         self.pid = os.getpid()
@@ -436,7 +437,7 @@ class ArcFlow:
         # add to solr after successful save
         try:
             result = subprocess.run(
-                f'FILE={xml_file_path} SOLR_URL={self.solr_url} REPOSITORY_ID={repo_id} bundle exec rails arclight:index',
+                f'FILE={xml_file_path} SOLR_URL={self.solr_url} REPOSITORY_ID={repo_id}  EXTRA_CONFIG ={self.traject_task} bundle exec rake arcuit:index',
                 shell=True,
                 cwd=self.arclight_dir,
                 stderr=subprocess.PIPE,)
@@ -520,13 +521,20 @@ def main():
         '--solr-url',
         required=True,
         help='URL of the Solr core',)
+    parser.add_argument(
+        '--traject-task',
+        required=False,
+        help='Path to a traject task file',
+    )
     args = parser.parse_args()
 
     arcflow = ArcFlow(
         arclight_dir=args.arclight_dir,
         aspace_dir=args.aspace_dir,
         solr_url=args.solr_url,
-        force_update=args.force_update)
+        force_update=args.force_update,
+        traject_task=args.traject_task
+    )
     arcflow.run()
 
 if __name__ == '__main__':

--- a/arcflow/main.py
+++ b/arcflow/main.py
@@ -34,12 +34,13 @@ class ArcFlow:
     """
 
 
-    def __init__(self, arclight_dir, aspace_dir, solr_url, force_update=False, traject_task=''):
+    def __init__(self, arclight_dir, aspace_dir, solr_url, data_path='../arclight/data',force_update=False, traject_task=''):
         self.solr_url = solr_url
         self.arclight_dir = arclight_dir
         self.aspace_dir = aspace_dir
         self.force_update = force_update
         self.traject_task = traject_task
+        self.data_path = data_path
 
         self.log = logging.getLogger('arcflow')
         self.pid = os.getpid()
@@ -437,7 +438,7 @@ class ArcFlow:
         # add to solr after successful save
         try:
             result = subprocess.run(
-                f'FILE={xml_file_path} SOLR_URL={self.solr_url} REPOSITORY_ID={repo_id}  EXTRA_CONFIG ={self.traject_task} bundle exec rake arcuit:index',
+                f'FILE={xml_file_path} SOLR_URL={self.solr_url} REPOSITORY_ID={repo_id}  TRAJECT_SETTINGS="aspace_classification_map_path={self.data_path}/aspace_classification_map.json" EXTRA_CONFIG={self.traject_task} bundle exec rake arcuit:index',
                 shell=True,
                 cwd=self.arclight_dir,
                 stderr=subprocess.PIPE,)
@@ -526,6 +527,11 @@ def main():
         required=False,
         help='Path to a traject task file',
     )
+    parser.add_argument(
+        '--data-path',
+        required=False,
+        help='Path to a data directory for data used by traject tasks',
+    )
     args = parser.parse_args()
 
     arcflow = ArcFlow(
@@ -533,7 +539,8 @@ def main():
         aspace_dir=args.aspace_dir,
         solr_url=args.solr_url,
         force_update=args.force_update,
-        traject_task=args.traject_task
+        traject_task=args.traject_task,
+        data_path=args.data_path
     )
     arcflow.run()
 

--- a/arcflow/utils/stage_classifications.py
+++ b/arcflow/utils/stage_classifications.py
@@ -1,3 +1,9 @@
+"""Harvest classification data from ArchivesSpace and output nested JSON.
+
+This script connects to an ArchivesSpace instance using ASnake, retrieves
+resource records from one or more repositories, and builds a nested JSON
+structure based on classification hierarchy (record groups, subgroups, collections).
+"""
 
 import os
 import json
@@ -5,14 +11,24 @@ import yaml
 import argparse
 from asnake.client import ASnakeClient
 
-def __get_asnake_client():
-    """Function to create and return an ASnakeClient instance."""
+
+def get_asnake_client():
+    """Creates and returns an authenticated ASnakeClient.
+
+    Loads credentials from .archivessnake.yml and authorizes the client.
+
+    Returns:
+        ASnakeClient: An authenticated ArchivesSpace client.
+
+    Raises:
+        SystemExit: If config file is missing or authentication fails.
+    """
     try:
         with open('.archivessnake.yml', 'r') as file:
             config = yaml.safe_load(file)
     except FileNotFoundError:
-        print('File .archivessnake.yml not found. Create the file.')
-        exit(0)
+        print('Error: .archivessnake.yml not found.')
+        exit(1)
 
     try:
         client = ASnakeClient(
@@ -22,31 +38,48 @@ def __get_asnake_client():
         )
         client.authorize()
         return client
-    except Exception as e:
-        print(f'Error authorizing ASnakeClient: {e}')
-        exit(0)
+    except Exception as error:
+        print(f'Error authorizing ASnakeClient: {error}')
+        exit(1)
 
-client = __get_asnake_client()
 
 def labels_from_path(path_from_root):
-    rg = sg = None
+    """Extracts record group and subgroup labels from a classification path.
+
+    Args:
+        path_from_root (list): List of classification nodes.
+
+    Returns:
+        tuple[str | None, str | None]: Record group label and subgroup label.
+    """
+    record_group = subgroup = None
     if path_from_root:
         rg_node = path_from_root[0]
         rg_id = rg_node.get('identifier')
-        rg_t = rg_node.get('title')
-        if rg_id and rg_t:
-            rg = f"{rg_id} — {rg_t}"
+        rg_title = rg_node.get('title')
+        if rg_id and rg_title:
+            record_group = f"{rg_id} — {rg_title}"
 
         if len(path_from_root) > 1:
             sg_node = path_from_root[1]
             sg_id = sg_node.get('identifier')
-            sg_t = sg_node.get('title')
+            sg_title = sg_node.get('title')
             code = f"{rg_id}.{sg_id}" if rg_id and sg_id else sg_id
-            if code and sg_t:
-                sg = f"{code} — {sg_t}"
-    return rg, sg
+            if code and sg_title:
+                subgroup = f"{code} — {sg_title}"
+
+    return record_group, subgroup
+
 
 def parse_eadid(eadid):
+    """Splits an EAD ID into its component parts.
+
+    Args:
+        eadid (str): EAD ID string (e.g., 'UI.12.3.45').
+
+    Returns:
+        tuple[str | None, str | None, str | None, str | None]: repo_code, rg_id, sg_id, col_id
+    """
     parts = eadid.split('.')
     repo_code = parts[0] if len(parts) > 0 else None
     rg_id = parts[1] if len(parts) > 1 else None
@@ -54,30 +87,54 @@ def parse_eadid(eadid):
     col_id = parts[3] if len(parts) > 3 else None
     return repo_code, rg_id, sg_id, col_id
 
+
 def extract_labels(resource):
+    """Extracts classification labels and metadata from a resource record.
+
+    Args:
+        resource (dict): A resource record from ArchivesSpace.
+
+    Returns:
+        tuple[str | None, str | None, str | None, str | None]: eadid, record_group_label, subgroup_label, title
+    """
     eadid = resource.get('ead_id', '').strip()
     title = resource.get('title', '').strip()
     if not eadid:
         return None, None, None, None
 
-    rg_label = sg_label = None
+    record_group_label = subgroup_label = None
     for link in resource.get('classifications', []):
         term = link.get('_resolved', {})
         path = term.get('path_from_root', [])
         rg, sg = labels_from_path(path)
         if rg:
-            rg_label = rg
+            record_group_label = rg
         if sg:
-            sg_label = sg
+            subgroup_label = sg
 
-    return eadid, rg_label, sg_label, title
+    if not record_group_label:
+        return None, None, None, None
 
-def process_repository(repo_id, map_data):
-    ids = client.get(f"/repositories/{repo_id}/resources?all_ids=true").json()
-    for i, id in enumerate(ids):
-        res = client.get(f"/repositories/{repo_id}/resources/{id}?resolve[]=classifications&resolve[]=classification_terms").json()
-        eadid, rg_label, sg_label, title = extract_labels(res)
-        if not eadid:
+    return eadid, record_group_label, subgroup_label, title
+
+
+def process_repository(repo_id, map_data, client):
+    """Processes all resources in a repository and updates the nested map.
+
+    Args:
+        repo_id (str): Repository ID.
+        map_data (dict): Nested classification map.
+        client (ASnakeClient): Authenticated ArchivesSpace client.
+    """
+    resource_ids = client.get(f"/repositories/{repo_id}/resources?all_ids=true").json()
+    for index, resource_id in enumerate(resource_ids):
+        resource = client.get(
+            f"/repositories/{repo_id}/resources/{resource_id}"
+            "?resolve[]=classifications&resolve[]=classification_terms"
+        ).json()
+
+        eadid, rg_label, sg_label, title = extract_labels(resource)
+        if not eadid or not rg_label:
             continue
 
         repo_code, rg_id, sg_id, col_id = parse_eadid(eadid)
@@ -85,42 +142,62 @@ def process_repository(repo_id, map_data):
             continue
 
         repo = map_data.setdefault(repo_code, {})
-        rg = repo.setdefault(rg_id, {'label': rg_label, 'subgroups': {}})
+        record_group = repo.setdefault(rg_id, {'label': rg_label, 'subgroups': {}})
 
         if sg_id:
-            sg = rg['subgroups'].setdefault(sg_id, {'label': sg_label, 'collections': {}})
+            subgroup = record_group['subgroups'].setdefault(
+                sg_id, {'label': sg_label, 'collections': {}}
+            )
             if col_id:
-                sg['collections'][eadid] = {'ead_id': eadid, 'title': title}
+                subgroup['collections'][eadid] = {'ead_id': eadid, 'title': title}
         else:
-            rg.setdefault('collections', {})[eadid] = {'ead_id': eadid, 'title': title}
+            record_group.setdefault('collections', {})[eadid] = {
+                'ead_id': eadid,
+                'title': title
+            }
 
-        print(f"[{i+1}/{len(ids)}] {eadid} -> RG={rg_label} SG={sg_label}")
+        print(f"[{index + 1}/{len(resource_ids)}] {eadid} -> RG={rg_label} SG={sg_label}")
+
 
 def main():
-    parser = argparse.ArgumentParser(description="Harvest classification data from ArchivesSpace.")
-    parser.add_argument('--repo-id', help='Repository ID to process. If omitted, all repositories will be processed.')
-    parser.add_argument('--out', help='Output JSON file path.', default='./aspace_classification_map.json')
+    """Main entry point for harvesting classification data."""
+    parser = argparse.ArgumentParser(
+        description="Harvest classification data from ArchivesSpace."
+    )
+    parser.add_argument(
+        '--repo-id',
+        help='Repository ID to process. If omitted, all repositories will be processed.'
+    )
+    parser.add_argument(
+        '--out',
+        help='Output JSON file path. Should be app root.',
+        default='./data/aspace_classification_map.json'
+    )
     args = parser.parse_args()
 
-    out_path = args.out
+    out_path = 'data/' + args.out
     repo_id = args.repo_id
 
     if os.path.exists(out_path):
-        with open(out_path, 'r') as f:
-            map_data = json.load(f)
+        with open(out_path, 'r') as file:
+            map_data = json.load(file)
     else:
         map_data = {}
 
-    repo_ids = [repo_id] if repo_id else [repo['uri'].split('/')[-1] for repo in client.get('/repositories').json()]
+    client = get_asnake_client()
+    repo_ids = [repo_id] if repo_id else [
+        repo['uri'].split('/')[-1] for repo in client.get('/repositories').json()
+    ]
 
     for rid in repo_ids:
         print(f"Processing repository {rid}...")
-        process_repository(rid, map_data)
+        process_repository(rid, map_data, client)
 
     os.makedirs(os.path.dirname(out_path), exist_ok=True)
-    with open(out_path, 'w') as f:
-        json.dump(map_data, f, indent=2)
+    with open(out_path, 'w') as file:
+        json.dump(map_data, file, indent=2)
     print(f"Wrote {out_path} ({len(map_data)} repositories)")
+
 
 if __name__ == "__main__":
     main()

--- a/arcflow/utils/stage_classifications.py
+++ b/arcflow/utils/stage_classifications.py
@@ -1,0 +1,126 @@
+
+import os
+import json
+import yaml
+import argparse
+from asnake.client import ASnakeClient
+
+def __get_asnake_client():
+    """Function to create and return an ASnakeClient instance."""
+    try:
+        with open('.archivessnake.yml', 'r') as file:
+            config = yaml.safe_load(file)
+    except FileNotFoundError:
+        print('File .archivessnake.yml not found. Create the file.')
+        exit(0)
+
+    try:
+        client = ASnakeClient(
+            username=config['username'],
+            password=config['password'],
+            baseurl=config['baseurl'],
+        )
+        client.authorize()
+        return client
+    except Exception as e:
+        print(f'Error authorizing ASnakeClient: {e}')
+        exit(0)
+
+client = __get_asnake_client()
+
+def labels_from_path(path_from_root):
+    rg = sg = None
+    if path_from_root:
+        rg_node = path_from_root[0]
+        rg_id = rg_node.get('identifier')
+        rg_t = rg_node.get('title')
+        if rg_id and rg_t:
+            rg = f"{rg_id} — {rg_t}"
+
+        if len(path_from_root) > 1:
+            sg_node = path_from_root[1]
+            sg_id = sg_node.get('identifier')
+            sg_t = sg_node.get('title')
+            code = f"{rg_id}.{sg_id}" if rg_id and sg_id else sg_id
+            if code and sg_t:
+                sg = f"{code} — {sg_t}"
+    return rg, sg
+
+def parse_eadid(eadid):
+    parts = eadid.split('.')
+    repo_code = parts[0] if len(parts) > 0 else None
+    rg_id = parts[1] if len(parts) > 1 else None
+    sg_id = parts[2] if len(parts) > 2 else None
+    col_id = parts[3] if len(parts) > 3 else None
+    return repo_code, rg_id, sg_id, col_id
+
+def extract_labels(resource):
+    eadid = resource.get('ead_id', '').strip()
+    title = resource.get('title', '').strip()
+    if not eadid:
+        return None, None, None, None
+
+    rg_label = sg_label = None
+    for link in resource.get('classifications', []):
+        term = link.get('_resolved', {})
+        path = term.get('path_from_root', [])
+        rg, sg = labels_from_path(path)
+        if rg:
+            rg_label = rg
+        if sg:
+            sg_label = sg
+
+    return eadid, rg_label, sg_label, title
+
+def process_repository(repo_id, map_data):
+    ids = client.get(f"/repositories/{repo_id}/resources?all_ids=true").json()
+    for i, id in enumerate(ids):
+        res = client.get(f"/repositories/{repo_id}/resources/{id}?resolve[]=classifications&resolve[]=classification_terms").json()
+        eadid, rg_label, sg_label, title = extract_labels(res)
+        if not eadid:
+            continue
+
+        repo_code, rg_id, sg_id, col_id = parse_eadid(eadid)
+        if not repo_code or not rg_id:
+            continue
+
+        repo = map_data.setdefault(repo_code, {})
+        rg = repo.setdefault(rg_id, {'label': rg_label, 'subgroups': {}})
+
+        if sg_id:
+            sg = rg['subgroups'].setdefault(sg_id, {'label': sg_label, 'collections': {}})
+            if col_id:
+                sg['collections'][eadid] = {'ead_id': eadid, 'title': title}
+        else:
+            rg.setdefault('collections', {})[eadid] = {'ead_id': eadid, 'title': title}
+
+        print(f"[{i+1}/{len(ids)}] {eadid} -> RG={rg_label} SG={sg_label}")
+
+def main():
+    parser = argparse.ArgumentParser(description="Harvest classification data from ArchivesSpace.")
+    parser.add_argument('--repo-id', help='Repository ID to process. If omitted, all repositories will be processed.')
+    parser.add_argument('--out', help='Output JSON file path.', default='./aspace_classification_map.json')
+    args = parser.parse_args()
+
+    out_path = args.out
+    repo_id = args.repo_id
+
+    if os.path.exists(out_path):
+        with open(out_path, 'r') as f:
+            map_data = json.load(f)
+    else:
+        map_data = {}
+
+    repo_ids = [repo_id] if repo_id else [repo['uri'].split('/')[-1] for repo in client.get('/repositories').json()]
+
+    for rid in repo_ids:
+        print(f"Processing repository {rid}...")
+        process_repository(rid, map_data)
+
+    os.makedirs(os.path.dirname(out_path), exist_ok=True)
+    with open(out_path, 'w') as f:
+        json.dump(map_data, f, indent=2)
+    print(f"Wrote {out_path} ({len(map_data)} repositories)")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### PR to support indexing additional data into Arclight Solr

#### Overview  
This adds functionality to fetch, stage, and process classification data from ArchivesSpace to be used in Arclight as recordgroup and subgroup. 

#### Fetch and Stage:
The utility script stage_classifications.py gets the classifications from Aspace collections and stores them in a nested json so that the they can be looked up during solr indexing:
```
  "UA": {
    "12": {
      "label": "UA 12 - Fine Arts and Applied Arts",
      "subgroups": {
        "5": {
          "label": "UA 12.5 - School of Music",
          "collections": {
            "UA.12.5.64": {
              "ead_id": "UA.12.5.64",
              "title": "School of Music Audio Department Sound Recordings"
            },
            "UA.12.5.68": {
              "ead_id": "UA.12.5.68",
              "title": "Lawrence Gushee Papers"
            },
 . . .
```
Example usage:
Process repo 8 and store the resulting mapping to /path/to/arclight
 `stage_classifications.py --repo-id 8 --out /path/to/arclight`

Process all repos and store the mappings in the default location (../arclight/data)
 `stage_classifications.py `

#### Process data to Solr index
Updates to main.py call the rake task arcuit:index instead of arclight:index, which adds the record_group and subgroup data to the solr index for collections. 
This interacts with the json data and expects it to be in the app_root/data/aspace_classification_map.json directory. So, when calling stage_classifications.py, give the --out argument the app root location or move it there before running indexing. When invoking arcflow, you can provide an different traject file using the` --traject-task='/path/to/file.rb' `flag and pass the location of the data mapping json using `--data-path=/path/to/aspace/data/aspace_classification_map.json`

### Testing

#generate the data mapping 
cd /opt/arclight/arcflow
arcflow/utils/stage_classifications.py --out /opt/arclight/arclight

cd ../arclight
should be able to invoke arcflow normally, but add data_path=/opt/arclight/arclight/data (or wherever it ended up). 

### Todo
--data-path passes its argument to TRAJECT_SETTINGS, which will process any setting. --data-path can be renamed if we want it to accept other kinds of settings. 

Should think about adding some functionality to stage_classifications.py to only get the add the mappings from records that have been added/changed since it was last run. It takes a few minutes to run through all of the collections (10k or so).

Should think about fetching the data live while doing the indexing. This struck me as slowing down the indexing while introducing a lot of failure points, so pre-fetching might always be preferred. 

Initially I was thinking there might be multiple data files, so passing the path and using a file name convention for data files made sense. But if this is the only data file, it would probably make more sense to pass the file location instead.