### PR TITLE
fix: check ead_id exists before accessing

### DIFF
--- a/arcflow/main.py
+++ b/arcflow/main.py
@@ -210,6 +210,9 @@ class ArcFlow:
                 'resolve': ['classifications', 'classification_terms', 'linked_agents'],
             }).json()
 
+        if "ead_id" not in resource:
+            self.log.error(f'{indent}Resource {resource_id} is missing an ead_id. Skipping.')
+            return pdf_job
         xml_file_path = f'{xml_dir}/{resource["ead_id"]}.xml'
 
         # replace dots with dashes in EAD ID to avoid issues with Solr


### PR DESCRIPTION
I ran into an issue while indexing where I got   `KeyError: 'ead_id'` on `xml_file_path = f'{xml_dir}/{resource["ead_id"]}.xml'` [here](https://github.com/UIUCLibrary/arcflow/blob/c2486e4cf0455655497a1f3aaa4aca3cefca2826/arcflow/main.py#L213).

It seems unusual that ead_id would be missing, so let me know if you'd like me to dig further.  