### PR TITLE
Hotfix avoid direct shell execution

### DIFF
--- a/arcflow/main.py
+++ b/arcflow/main.py
@@ -9,6 +9,7 @@ import subprocess
 import re
 import logging
 import math
+import glob
 from xml.dom.pulldom import parse, START_ELEMENT
 from xml.sax.saxutils import escape as xml_escape
 from datetime import datetime, timezone
@@ -41,7 +42,7 @@ class ArcFlow:
     def __init__(self, arclight_dir, aspace_dir, solr_url, traject_extra_config='', force_update=False):
         self.solr_url = solr_url
         self.batch_size = 1000
-        self.traject_extra_config = f'-c {traject_extra_config}' if traject_extra_config.strip() else ''
+        self.traject_extra_config = traject_extra_config if traject_extra_config.strip() else ''
         self.arclight_dir = arclight_dir
         self.aspace_jobs_dir = f'{aspace_dir}/data/shared/job_files'
         self.job_type = 'print_to_pdf_job'
@@ -466,19 +467,18 @@ class ArcFlow:
                 r.get()
 
             # Remove pending symlinks after indexing
-            for repo_id, batch_num in batches:
-                xml_file_path = f'{xml_dir}/{repo_id}_*_batch_{batch_num}.xml'
-                try:
-                    result = subprocess.run(
-                        f'rm {xml_file_path}',
-                        shell=True,
-                        cwd=self.arclight_dir,
-                        stderr=subprocess.PIPE,)
-                    self.log.error(f'{" " * indent_size}{result.stderr.decode("utf-8")}')
-                    if result.returncode != 0:
-                        self.log.error(f'{" " * indent_size}Failed to remove pending symlinks {xml_file_path}. Return code: {result.returncode}')
-                except Exception as e:
-                    self.log.error(f'{" " * indent_size}Error removing pending symlinks {xml_file_path}: {e}')
+                for repo_id, batch_num in batches:
+                    xml_file_pattern = f'{xml_dir}/{repo_id}_*_batch_{batch_num}.xml'
+                    xml_files = glob.glob(xml_file_pattern)
+
+                    for xml_file_path in xml_files:
+                        try:
+                            os.remove(xml_file_path)
+                            self.log.info(f'{" " * indent_size}Removed pending symlink {xml_file_path}')
+                        except FileNotFoundError:
+                            self.log.warning(f'{" " * indent_size}File not found: {xml_file_path}')
+                        except Exception as e:
+                            self.log.error(f'{" " * indent_size}Error removing pending symlink {xml_file_path}: {e}')
 
             # Tasks for processing PDFs
             results_4 = [pool.apply_async(
@@ -534,12 +534,56 @@ class ArcFlow:
         indent = ' ' * indent_size
         self.log.info(f'{indent}Indexing pending resources in repository ID {repo_id} to ArcLight Solr...')
         try:
+
+            # Set traject config path
+
+            # Make sure we can find arclight path
+            result_show = subprocess.run(
+                ['bundle', 'show', 'arclight'],
+                capture_output=True,
+                text=True,
+                cwd=self.arclight_dir
+            )
+            arclight_path = result_show.stdout.strip() if result_show.returncode == 0 else ''
+
+            if not arclight_path:
+                self.log.error(f'{indent}Could not find arclight gem path')
+                return
+
+            traject_config = f'{arclight_path}/lib/arclight/traject/ead2_config.rb'
+
+            # Expand wildcards with glob to get files list
+            xml_files = glob.glob(xml_file_path)
+
+            if not xml_files:
+                self.log.warning(f'{indent}No files found matching pattern: {xml_file_path}')
+                return
+
+
+            cmd = [
+                'bundle', 'exec', 'traject',
+                '-u', self.solr_url,
+                '-s', 'processing_thread_pool=8',
+                '-s', 'solr_writer.thread_pool=8',
+                '-s', f'solr_writer.batch_size={self.batch_size}',
+                '-s', 'solr_writer.commit_on_close=true',
+                '-i', 'xml',
+                '-c', traject_config,
+                '-c', self.traject_extra_config,
+                *xml_files
+            ]
+
+            env = os.environ.copy()
+            env['REPOSITORY_ID'] = str(repo_id)
+
             result = subprocess.run(
-                f'REPOSITORY_ID={repo_id} bundle exec traject -u {self.solr_url} -s processing_thread_pool=8 -s solr_writer.thread_pool=8 -s solr_writer.batch_size={self.batch_size} -s solr_writer.commit_on_close=true -i xml -c $(bundle show arclight)/lib/arclight/traject/ead2_config.rb {self.traject_extra_config} {xml_file_path}',
-#                f'FILE={xml_file_path} SOLR_URL={self.solr_url} REPOSITORY_ID={repo_id}  TRAJECT_SETTINGS="processing_thread_pool=8 solr_writer.thread_pool=8 solr_writer.batch_size=1000 solr_writer.commit_on_close=false" bundle exec rake arcuit:index',
-                shell=True,
+                cmd,
                 cwd=self.arclight_dir,
-                stderr=subprocess.PIPE,)
+                env=env,
+                stderr=subprocess.PIPE,
+            )
+
+
             self.log.error(f'{indent}{result.stderr.decode("utf-8")}')
             if result.returncode != 0:
                 self.log.error(f'{indent}Failed to index pending resources in repository ID {repo_id} to ArcLight Solr. Return code: {result.returncode}')
@@ -781,9 +825,9 @@ def main():
         required=True,
         help='URL of the Solr core',)
     parser.add_argument(
-        '--traject-extra-config',
-        default='',
-        help='Path to extra Traject configuration file',)
+            '--traject-extra-config',
+            default='',
+            help='Path to extra Traject configuration file',)
     args = parser.parse_args()
 
     arcflow = ArcFlow(

--- a/arcflow/main.py
+++ b/arcflow/main.py
@@ -569,9 +569,10 @@ class ArcFlow:
                 '-s', 'solr_writer.commit_on_close=true',
                 '-i', 'xml',
                 '-c', traject_config,
-                '-c', self.traject_extra_config,
-                *xml_files
             ]
+            if self.traject_extra_config:
+                cmd.extend(['-c', self.traject_extra_config])
+            cmd.extend(xml_files)
 
             env = os.environ.copy()
             env['REPOSITORY_ID'] = str(repo_id)

--- a/arcflow/main.py
+++ b/arcflow/main.py
@@ -34,7 +34,7 @@ logging.basicConfig(
 
 class ArcFlow:
     """
-    ArcFlow is a class that represents a flow of data from ArchivesSpace 
+    ArcFlow is a class that represents a flow of data from ArchivesSpace
     to ArcLight.
     """
 
@@ -43,7 +43,18 @@ class ArcFlow:
         self.solr_url = solr_url
         self.batch_size = 1000
         self.arclight_dir = arclight_dir
-        self.ead_extra_config = ead_extra_config if ead_extra_config.strip() else f'{self.arclight_dir}/lib/arcuit/traject/ead_extra_config.rb'
+        if ead_extra_config.strip():
+            if not os.path.isfile(ead_extra_config):
+                raise FileNotFoundError(f'Specified ead_extra_config not found: {ead_extra_config}')
+            self.ead_extra_config = ead_extra_config
+        else:
+            default_config = f'{self.arclight_dir}/lib/arcuit/traject/ead_extra_config.rb'
+            if os.path.isfile(default_config):
+                self.ead_extra_config = default_config
+                logging.info(f'Using default ead_extra_config: {default_config}')
+            else:
+                self.ead_extra_config = None
+                logging.warning(f'Default ead_extra_config not found at {default_config}. Proceeding without extra config.')
         self.aspace_jobs_dir = f'{aspace_dir}/data/shared/job_files'
         self.job_type = 'print_to_pdf_job'
         self.force_update = force_update
@@ -129,7 +140,7 @@ class ArcFlow:
 
             update_repos = False
             for repo in repos:
-                # python doesn't support Zulu timezone suffixes, 
+                # python doesn't support Zulu timezone suffixes,
                 # converting system_mtime and user_mtime to UTC offset notation
                 if (self.last_updated <= datetime.strptime(
                         repo['system_mtime'].replace('Z','+0000'),
@@ -187,7 +198,7 @@ class ArcFlow:
 
                         yaml.safe_dump({
                             self.get_repo_id(repo): {
-                                k:repo[k] if k in repo else "" 
+                                k:repo[k] if k in repo else ""
                                 for k in (
                                     'name',
                                     'description',

--- a/arcflow/main.py
+++ b/arcflow/main.py
@@ -39,11 +39,11 @@ class ArcFlow:
     """
 
 
-    def __init__(self, arclight_dir, aspace_dir, solr_url, traject_extra_config='', force_update=False):
+    def __init__(self, arclight_dir, aspace_dir, solr_url, ead_extra_config='', force_update=False):
         self.solr_url = solr_url
         self.batch_size = 1000
-        self.traject_extra_config = traject_extra_config if traject_extra_config.strip() else ''
         self.arclight_dir = arclight_dir
+        self.ead_extra_config = ead_extra_config if ead_extra_config.strip() else f'{self.arclight_dir}/lib/arcuit/traject/ead_extra_config.rb'
         self.aspace_jobs_dir = f'{aspace_dir}/data/shared/job_files'
         self.job_type = 'print_to_pdf_job'
         self.force_update = force_update
@@ -570,8 +570,8 @@ class ArcFlow:
                 '-i', 'xml',
                 '-c', traject_config,
             ]
-            if self.traject_extra_config:
-                cmd.extend(['-c', self.traject_extra_config])
+            if self.ead_extra_config:
+                cmd.extend(['-c', self.ead_extra_config])
             cmd.extend(xml_files)
 
             env = os.environ.copy()
@@ -826,16 +826,16 @@ def main():
         required=True,
         help='URL of the Solr core',)
     parser.add_argument(
-            '--traject-extra-config',
+            '--ead-extra-config',
             default='',
-            help='Path to extra Traject configuration file',)
+            help='Path to extra Traject EAD configuration file',)
     args = parser.parse_args()
 
     arcflow = ArcFlow(
         arclight_dir=args.arclight_dir,
         aspace_dir=args.aspace_dir,
         solr_url=args.solr_url,
-        traject_extra_config=args.traject_extra_config,
+        ead_extra_config=args.ead_extra_config,
         force_update=args.force_update)
     arcflow.run()
 


### PR DESCRIPTION
Copilot was directing me to use a list format for `subprocess.run` command's `cwd` that I was issuing as part of the creator indexing and was suggesting that running `shell=True` posed a security risk, which seems like a reasonable concern, and said that it made it more portable, which is probably technically true given different shell environments. So, I thought I would refactor this to match. 

I think the list format is also a little more legible when reviewing the traject command that is being issued. 

However, not being able to directly compose in bash syntax means that some things (like wildcard expansion) are more verbose. So, let me know what you think. 

I also remove the traject extra config as I don't think we'll use it and will instead make separate workflows for different traject tasks and that feature was making clutter.  

Also, submitting this as a separate pr to main in part because the creators pr is getting pretty extensive so I'm trying to carve out anything like this that was just general refactor away from the feature logic. 